### PR TITLE
Increase pbr requirement from 0.11 to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ funcsigs;python_version<"3.3"
 # For runtime needs this is correct. For setup_requires needs, 1.2.0 is needed
 # but setuptools can't cope with conflicts in setup_requires, so thats
 # unversioned.
-pbr>=0.11
+pbr>=1.0.0
 six>=1.7


### PR DESCRIPTION
Installation of mock 1.1.1 fails with pbr 0.11.0, but succeeds with
pbr 1.0.0.

    error in setup command: 'install_requires' must be a string or
    list of strings containing valid project/version requirement
    specifiers