### PR TITLE
Require setuptools>=17.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ import setuptools
 
 
 setuptools.setup(
-    setup_requires=['pbr'],
+    setup_requires=['pbr', 'setuptools>=17.1'],
     pbr=True)


### PR DESCRIPTION
17.1 introduces new range operators for environment marker evaluation. mock uses this, so it requires a version of setuptools greater than or equal to 17.1. If a user attempts to install mock with a version less than 17.1, it will break.

See https://pythonhosted.org/setuptools/history.html#id5 for additional details