### PR TITLE
Closes #269: setup_requires pbr 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ import setuptools
 
 
 setuptools.setup(
-    setup_requires=['pbr'],
+    setup_requires=['pbr>=1.3'],
     pbr=True)


### PR DESCRIPTION
less than 1.3 and the boolean environment marker expression is
reflected into setuptools incorrectly.