### PR TITLE
Added note for Python 2.6 and mock 1.0.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@ mock is now part of the Python standard library, available as `unittest.mock
 onwards.
 
 This package contains a rolling backport of the standard library mock code
-compatible with Python 2.7 and up, and 3.2 and up.
+compatible with Python 2.7 and up, and 3.2 and up. (Python 2.6 is not officially 
+supported but you may be able to work by pinning `mock==1.0.1` in you requirements.)
 
 Please see the standard library documentation for more details.
 


### PR DESCRIPTION
I ran into a breaking build on Django Compressor after the upgrade from 1.0.1. Pinning here fixes the build. Not sure about your attitude to Python 2.6. Am happy to make edits here as you see fit.