### PR TITLE
Revert "Issue #21750: mock_open.read_data can now be read from each i…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,3 @@
-Library
--------
-
-- Issue #21750: mock_open.read_data can now be read from each instance, as it
-  could in Python 3.3.
-
 - Issue #18622: unittest.mock.mock_open().reset_mock would recurse infinitely.
   Patch from Nicola Palumbo and Laurent De Buyst.
 

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -2453,7 +2453,6 @@ def _iterate_read_data(read_data):
     for line in data_as_list:
         yield line
 
-
 def mock_open(mock=None, read_data=''):
     """
     A helper function to create a mock to replace the use of `open`. It works
@@ -2496,42 +2495,21 @@ def mock_open(mock=None, read_data=''):
     if mock is None:
         mock = MagicMock(name='open', spec=open)
 
-    def make_handle(*args, **kwargs):
-        # Arg checking is handled by __call__
-        def _readlines_side_effect(*args, **kwargs):
-            if handle.readlines.return_value is not None:
-                return handle.readlines.return_value
-            return list(_data)
+    handle = MagicMock(spec=file_spec)
+    handle.__enter__.return_value = handle
 
-        def _read_side_effect(*args, **kwargs):
-            if handle.read.return_value is not None:
-                return handle.read.return_value
-            return ''.join(_data)
+    _data = _iterate_read_data(read_data)
 
-        def _readline_side_effect():
-            if handle.readline.return_value is not None:
-                while True:
-                    yield handle.readline.return_value
-            for line in _data:
-                yield line
+    handle.write.return_value = None
+    handle.read.return_value = None
+    handle.readline.return_value = None
+    handle.readlines.return_value = None
 
-        handle = MagicMock(spec=file_spec)
-        handle.__enter__.return_value = handle
+    handle.read.side_effect = _read_side_effect
+    handle.readline.side_effect = _readline_side_effect()
+    handle.readlines.side_effect = _readlines_side_effect
 
-        _data = _iterate_read_data(read_data)
-
-        handle.write.return_value = None
-        handle.read.return_value = None
-        handle.readline.return_value = None
-        handle.readlines.return_value = None
-
-        handle.read.side_effect = _read_side_effect
-        handle.readline.side_effect = _readline_side_effect()
-        handle.readlines.side_effect = _readlines_side_effect
-        _check_and_set_parent(mock, handle, None, '()')
-        return handle
-
-    mock.side_effect = make_handle
+    mock.return_value = handle
     return mock
 
 

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -1436,11 +1436,6 @@ class MockTest(unittest.TestCase):
             self.assertEqual(m.mock_calls, [call.__int__(), call.__float__()])
             self.assertEqual(m.method_calls, [])
 
-    def test_mock_open_reuse_issue_21750(self):
-        mocked_open = mock.mock_open(read_data='data')
-        f1 = mocked_open('a-name')
-        f2 = mocked_open('another-name')
-        self.assertEqual(f1.read(), f2.read())
 
     def test_mock_parents(self):
         for Klass in Mock, MagicMock:

--- a/mock/tests/testwith.py
+++ b/mock/tests/testwith.py
@@ -146,6 +146,7 @@ class TestMockOpen(unittest.TestCase):
 
     def test_mock_open_context_manager(self):
         mock = mock_open()
+        handle = mock.return_value
         with patch('%s.open' % __name__, mock, create=True):
             with open('foo') as f:
                 f.read()
@@ -153,23 +154,8 @@ class TestMockOpen(unittest.TestCase):
         expected_calls = [call('foo'), call().__enter__(), call().read(),
                           call().__exit__(None, None, None)]
         self.assertEqual(mock.mock_calls, expected_calls)
-        # mock_open.return_value is no longer static, because
-        # readline support requires that it mutate state
+        self.assertIs(f, handle)
 
-    def test_mock_open_context_manager_multiple_times(self):
-        mock = mock_open()
-        with patch('%s.open' % __name__, mock, create=True):
-            with open('foo') as f:
-                f.read()
-            with open('bar') as f:
-                f.read()
-
-        expected_calls = [
-            call('foo'), call().__enter__(), call().read(),
-            call().__exit__(None, None, None),
-            call('bar'), call().__enter__(), call().read(),
-            call().__exit__(None, None, None)]
-        self.assertEqual(mock.mock_calls, expected_calls)
 
     def test_explicit_mock(self):
         mock = MagicMock()


### PR DESCRIPTION
…nstance, as it"

This reverts commit e9db0161fc11eceba189a0cc161deefce57529a8.

Issue #288 - mock_open.return_value.<stuff here> was a widely used pattern.