### PR TITLE
Use six to provide Python2 and Python3 compatibility

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -74,9 +74,6 @@ version_info = _v.version_tuple()
 
 import mock
 
-inPy3k = sys.version_info[0] == 3
-
-
 try:
     inspectsignature = inspect.signature
 except AttributeError:
@@ -118,7 +115,7 @@ except NameError:
     # Python 2.4 compatibility
     BaseException = Exception
 
-if not inPy3k:
+if six.PY2:
     # Python 2's next() can't handle a non-iterator with a __next__ method.
     _next = next
     def next(obj, _next=_next):
@@ -151,7 +148,7 @@ except AttributeError:
 
 self = 'im_self'
 builtin = '__builtin__'
-if inPy3k:
+if six.PY3:
     self = '__self__'
     builtin = 'builtins'
 
@@ -250,7 +247,7 @@ def _copy_func_details(func, funcopy):
         funcopy.__kwdefaults__ = func.__kwdefaults__
     except AttributeError:
         pass
-    if not inPy3k:
+    if six.PY2:
         funcopy.func_defaults = func.func_defaults
         return
 
@@ -276,7 +273,7 @@ def _instance_callable(obj):
         # already an instance
         return getattr(obj, '__call__', None) is not None
 
-    if inPy3k:
+    if six.PY3:
         # *could* be broken by a class overriding __mro__ or __dict__ via
         # a metaclass
         for base in (obj,) + obj.__mro__:
@@ -410,7 +407,7 @@ def _copy(value):
 
 
 ClassTypes = (type,)
-if not inPy3k:
+if six.PY2:
     ClassTypes = (type, ClassType)
 
 _allowed_names = set((
@@ -926,7 +923,7 @@ class NonCallableMock(Base):
 
         def _error_message(cause):
             msg = self._format_mock_failure_message(args, kwargs)
-            if not inPy3k and cause is not None:
+            if six.PY2 and cause is not None:
                 # Tack on some diagnostics for Python without __cause__
                 msg = '%s\n%s' % (msg, str(cause))
             return msg
@@ -1826,12 +1823,12 @@ magic_methods = (
 numerics = (
     "add sub mul matmul div floordiv mod lshift rshift and xor or pow"
 )
-if inPy3k:
+if six.PY3:
     numerics += ' truediv'
 inplace = ' '.join('i%s' % n for n in numerics.split())
 right = ' '.join('r%s' % n for n in numerics.split())
 extra = ''
-if inPy3k:
+if six.PY3:
     extra = 'bool next '
 else:
     extra = 'unicode long nonzero oct hex truediv rtruediv '
@@ -2486,7 +2483,7 @@ def mock_open(mock=None, read_data=''):
     global file_spec
     if file_spec is None:
         # set on first use
-        if inPy3k:
+        if six.PY3:
             import _io
             file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
         else:

--- a/mock/tests/support.py
+++ b/mock/tests/support.py
@@ -11,7 +11,6 @@ except NameError:
         return hasattr(obj, '__call__')
 
 
-inPy3k = sys.version_info[0] == 3
 with_available = sys.version_info[:2] >= (2, 5)
 
 

--- a/mock/tests/support.py
+++ b/mock/tests/support.py
@@ -1,7 +1,7 @@
 import sys
+import unittest
 
 info = sys.version_info
-import unittest2
 
 
 try:

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -4,7 +4,6 @@
 
 from __future__ import division
 
-import unittest2 as unittest
 
 from mock.tests.support import inPy3k
 
@@ -18,6 +17,8 @@ except NameError:
 import inspect
 import sys
 import textwrap
+import unittest
+
 from mock import Mock, MagicMock
 from mock.mock import _magics
 

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -404,7 +404,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock = MagicMock()
         def set_setattr():
             mock.__setattr__ = lambda self, name: None
-        self.assertRaisesRegex(AttributeError,
+        six.assertRaisesRegex(self, AttributeError,
             "Attempting to set unsupported magic method '__setattr__'.",
             set_setattr
         )

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -4,9 +4,6 @@
 
 from __future__ import division
 
-
-from mock.tests.support import inPy3k
-
 try:
     unicode
 except NameError:
@@ -14,6 +11,7 @@ except NameError:
     unicode = str
     long = int
 
+import six
 import inspect
 import sys
 import textwrap
@@ -87,7 +85,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(str(mock), 'foo')
 
 
-    @unittest.skipIf(inPy3k, "no unicode in Python 3")
+    @unittest.skipIf(six.PY3, "no unicode in Python 3")
     def test_unicode(self):
         mock = Mock()
         self.assertEqual(unicode(mock), unicode(str(mock)))
@@ -167,7 +165,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(mock.value, 16)
 
         del mock.__truediv__
-        if inPy3k:
+        if six.PY3:
             def itruediv(mock):
                 mock /= 4
             self.assertRaises(TypeError, itruediv, mock)
@@ -199,7 +197,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertTrue(bool(m))
 
         nonzero = lambda s: False
-        if not inPy3k:
+        if six.PY2:
             m.__nonzero__ = nonzero
         else:
             m.__bool__ = nonzero
@@ -217,7 +215,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self. assertTrue(mock <= 3)
         self. assertTrue(mock >= 3)
 
-        if not inPy3k:
+        if six.PY2:
             # incomparable in Python 3
             self.assertEqual(Mock() < 3, object() < 3)
             self.assertEqual(Mock() > 3, object() > 3)
@@ -295,7 +293,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         name = '__nonzero__'
         other = '__bool__'
-        if inPy3k:
+        if six.PY3:
             name, other = other, name
         getattr(mock, name).return_value = False
         self.assertFalse(hasattr(mock, other))
@@ -331,7 +329,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(unicode(mock), object.__str__(mock))
         self.assertIsInstance(unicode(mock), unicode)
         self.assertTrue(bool(mock))
-        if not inPy3k:
+        if six.PY2:
             self.assertEqual(oct(mock), '1')
         else:
             # in Python 3 oct and hex use __index__
@@ -341,7 +339,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         # how to test __sizeof__ ?
 
 
-    @unittest.skipIf(inPy3k, "no __cmp__ in Python 3")
+    @unittest.skipIf(six.PY3, "no __cmp__ in Python 3")
     def test_non_default_magic_methods(self):
         mock = MagicMock()
         self.assertRaises(AttributeError, lambda: mock.__cmp__)

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -207,7 +207,7 @@ class MockTest(unittest.TestCase):
 
         mock = create_autospec(f)
         mock.side_effect = ValueError('Bazinga!')
-        self.assertRaisesRegex(ValueError, 'Bazinga!', mock)
+        six.assertRaisesRegex(self, ValueError, 'Bazinga!', mock)
 
     @unittest.skipUnless('java' in sys.platform,
                           'This test only applies to Jython')
@@ -500,7 +500,8 @@ class MockTest(unittest.TestCase):
 
                 # this should be allowed
                 mock.something
-                self.assertRaisesRegex(
+                six.assertRaisesRegex(
+                    self,
                     AttributeError,
                     "Mock object has no attribute 'something_else'",
                     getattr, mock, 'something_else'
@@ -519,12 +520,14 @@ class MockTest(unittest.TestCase):
             mock.x
             mock.y
             mock.__something__
-            self.assertRaisesRegex(
+            six.assertRaisesRegex(
+                self,
                 AttributeError,
                 "Mock object has no attribute 'z'",
                 getattr, mock, 'z'
             )
-            self.assertRaisesRegex(
+            six.assertRaisesRegex(
+                self,
                 AttributeError,
                 "Mock object has no attribute '__foobar__'",
                 getattr, mock, '__foobar__'
@@ -590,13 +593,13 @@ class MockTest(unittest.TestCase):
 
     def test_assert_called_with_message(self):
         mock = Mock()
-        self.assertRaisesRegex(AssertionError, 'Not called',
-                                mock.assert_called_with)
+        six.assertRaisesRegex(self, AssertionError, 'Not called',
+                               mock.assert_called_with)
 
 
     def test_assert_called_once_with_message(self):
         mock = Mock(name='geoffrey')
-        self.assertRaisesRegex(AssertionError,
+        six.assertRaisesRegex(self, AssertionError,
                      r"Expected 'geoffrey' to be called once\.",
                      mock.assert_called_once_with)
 

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -3,9 +3,10 @@
 # http://www.voidspace.org.uk/python/mock/
 
 from mock.tests.support import (
-    callable, inPy3k, is_instance, next
+    callable, is_instance, next
 )
 
+import six
 import copy
 import pickle
 import sys
@@ -663,7 +664,7 @@ class MockTest(unittest.TestCase):
         copy.copy(Mock())
 
 
-    @unittest.skipIf(inPy3k, "no old style classes in Python 3")
+    @unittest.skipIf(six.PY3, "no old style classes in Python 3")
     def test_spec_old_style_classes(self):
         class Foo:
             bar = 7
@@ -677,7 +678,7 @@ class MockTest(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: mock.foo)
 
 
-    @unittest.skipIf(inPy3k, "no old style classes in Python 3")
+    @unittest.skipIf(six.PY3, "no old style classes in Python 3")
     def test_spec_set_old_style_classes(self):
         class Foo:
             bar = 7

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -2,7 +2,6 @@
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
 # http://www.voidspace.org.uk/python/mock/
 
-import unittest2 as unittest
 from mock.tests.support import (
     callable, inPy3k, is_instance, next
 )
@@ -11,6 +10,7 @@ import copy
 import pickle
 import sys
 import tempfile
+import unittest
 
 import mock
 from mock import (

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -4,10 +4,11 @@
 
 import os
 import sys
+import six
 import unittest
 
 from mock.tests import support
-from mock.tests.support import inPy3k, SomeClass, is_instance, callable
+from mock.tests.support import SomeClass, is_instance, callable
 
 from mock import (
     NonCallableMock, CallableMixin, patch, sentinel,
@@ -17,7 +18,7 @@ from mock import (
 from mock.mock import _patch, _get_target
 
 builtin_string = '__builtin__'
-if inPy3k:
+if six.PY3:
     builtin_string = 'builtins'
     unicode = str
 

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -4,8 +4,7 @@
 
 import os
 import sys
-
-import unittest2 as unittest
+import unittest
 
 from mock.tests import support
 from mock.tests.support import inPy3k, SomeClass, is_instance, callable

--- a/mock/tests/testsentinel.py
+++ b/mock/tests/testsentinel.py
@@ -2,7 +2,7 @@
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
 # http://www.voidspace.org.uk/python/mock/
 
-import unittest2 as unittest
+import unittest
 
 from mock import sentinel, DEFAULT
 

--- a/mock/tests/testwith.py
+++ b/mock/tests/testwith.py
@@ -4,7 +4,7 @@
 
 from warnings import catch_warnings
 
-import unittest2 as unittest
+import unittest
 
 from mock.tests.support import is_instance
 from mock import MagicMock, Mock, patch, sentinel, mock_open, call

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.2


### PR DESCRIPTION
This is the enhanced version of the patch using in the Debian package `python-mock-1.3.0-1` that makes the tests run on both Python (>= 2.7) and (>= 3.2). Its main goal is to wrap `assertRaisesRegex` into the method provided by six tackle different names in Python2 and Python3.
It also replaces the internal Python version detection with the one provided by six.
The `unittest` package is now imported using its canonical name instead of renaming `unittest2`.
Python2.6 is no longer mentioned in the classifiers as the testsuite relies on `assertRaisesRegex`which is only available in Python2.7 (or Python3).