### PR TITLE
Use six Python version detection instead of custom one

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -74,9 +74,6 @@ version_info = _v.version_tuple()
 
 import mock
 
-inPy3k = sys.version_info[0] == 3
-
-
 try:
     inspectsignature = inspect.signature
 except AttributeError:
@@ -118,7 +115,7 @@ except NameError:
     # Python 2.4 compatibility
     BaseException = Exception
 
-if not inPy3k:
+if six.PY2:
     # Python 2's next() can't handle a non-iterator with a __next__ method.
     _next = next
     def next(obj, _next=_next):
@@ -151,7 +148,7 @@ except AttributeError:
 
 self = 'im_self'
 builtin = '__builtin__'
-if inPy3k:
+if six.PY3:
     self = '__self__'
     builtin = 'builtins'
 
@@ -250,7 +247,7 @@ def _copy_func_details(func, funcopy):
         funcopy.__kwdefaults__ = func.__kwdefaults__
     except AttributeError:
         pass
-    if not inPy3k:
+    if six.PY2:
         funcopy.func_defaults = func.func_defaults
         return
 
@@ -276,7 +273,7 @@ def _instance_callable(obj):
         # already an instance
         return getattr(obj, '__call__', None) is not None
 
-    if inPy3k:
+    if six.PY3:
         # *could* be broken by a class overriding __mro__ or __dict__ via
         # a metaclass
         for base in (obj,) + obj.__mro__:
@@ -410,7 +407,7 @@ def _copy(value):
 
 
 ClassTypes = (type,)
-if not inPy3k:
+if six.PY2:
     ClassTypes = (type, ClassType)
 
 _allowed_names = set((
@@ -926,7 +923,7 @@ class NonCallableMock(Base):
 
         def _error_message(cause):
             msg = self._format_mock_failure_message(args, kwargs)
-            if not inPy3k and cause is not None:
+            if six.PY2 and cause is not None:
                 # Tack on some diagnostics for Python without __cause__
                 msg = '%s\n%s' % (msg, str(cause))
             return msg
@@ -1826,12 +1823,12 @@ magic_methods = (
 numerics = (
     "add sub mul matmul div floordiv mod lshift rshift and xor or pow"
 )
-if inPy3k:
+if six.PY3:
     numerics += ' truediv'
 inplace = ' '.join('i%s' % n for n in numerics.split())
 right = ' '.join('r%s' % n for n in numerics.split())
 extra = ''
-if inPy3k:
+if six.PY3:
     extra = 'bool next '
 else:
     extra = 'unicode long nonzero oct hex truediv rtruediv '
@@ -2486,7 +2483,7 @@ def mock_open(mock=None, read_data=''):
     global file_spec
     if file_spec is None:
         # set on first use
-        if inPy3k:
+        if six.PY3:
             import _io
             file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
         else:

--- a/mock/tests/support.py
+++ b/mock/tests/support.py
@@ -11,7 +11,6 @@ except NameError:
         return hasattr(obj, '__call__')
 
 
-inPy3k = sys.version_info[0] == 3
 with_available = sys.version_info[:2] >= (2, 5)
 
 

--- a/mock/tests/testhelpers.py
+++ b/mock/tests/testhelpers.py
@@ -2,8 +2,9 @@
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
 # http://www.voidspace.org.uk/python/mock/
 
+import six
+
 import unittest2 as unittest
-from mock.tests.support import inPy3k
 
 from mock import (
     call, create_autospec, MagicMock,
@@ -403,7 +404,7 @@ class SpecSignatureTest(unittest.TestCase):
         m = create_autospec(Foo, a='3')
         self.assertEqual(m.a, '3')
 
-    @unittest.skipUnless(inPy3k, "Keyword only arguments Python 3 specific")
+    @unittest.skipUnless(six.PY3, "Keyword only arguments Python 3 specific")
     def test_create_autospec_keyword_only_arguments(self):
         func_def = "def foo(a, *, b=None):\n    pass\n"
         namespace = {}
@@ -558,7 +559,7 @@ class SpecSignatureTest(unittest.TestCase):
             mock.g.assert_called_once_with(3, 4)
 
 
-    @unittest.skipIf(inPy3k, "No old style classes in Python 3")
+    @unittest.skipIf(six.PY3, "No old style classes in Python 3")
     def test_old_style_classes(self):
         class Foo:
             def f(self, a, b):
@@ -745,7 +746,7 @@ class SpecSignatureTest(unittest.TestCase):
         mock.assert_called_with(4, 5)
 
 
-    @unittest.skipIf(inPy3k, 'no old style classes in Python 3')
+    @unittest.skipIf(six.PY3, 'no old style classes in Python 3')
     def test_signature_old_style_class(self):
         class Foo:
             def __init__(self, a, b=3):
@@ -773,7 +774,7 @@ class SpecSignatureTest(unittest.TestCase):
         create_autospec(Foo)
 
 
-    @unittest.skipIf(inPy3k, 'no old style classes in Python 3')
+    @unittest.skipIf(six.PY3, 'no old style classes in Python 3')
     def test_old_style_class_with_no_init(self):
         # this used to raise an exception
         # due to Foo.__init__ raising an AttributeError

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -6,8 +6,6 @@ from __future__ import division
 
 import unittest2 as unittest
 
-from mock.tests.support import inPy3k
-
 try:
     unicode
 except NameError:
@@ -15,6 +13,7 @@ except NameError:
     unicode = str
     long = int
 
+import six
 import inspect
 import sys
 import textwrap
@@ -86,7 +85,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(str(mock), 'foo')
 
 
-    @unittest.skipIf(inPy3k, "no unicode in Python 3")
+    @unittest.skipIf(six.PY3, "no unicode in Python 3")
     def test_unicode(self):
         mock = Mock()
         self.assertEqual(unicode(mock), unicode(str(mock)))
@@ -166,7 +165,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(mock.value, 16)
 
         del mock.__truediv__
-        if inPy3k:
+        if six.PY3:
             def itruediv(mock):
                 mock /= 4
             self.assertRaises(TypeError, itruediv, mock)
@@ -198,7 +197,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertTrue(bool(m))
 
         nonzero = lambda s: False
-        if not inPy3k:
+        if six.PY2:
             m.__nonzero__ = nonzero
         else:
             m.__bool__ = nonzero
@@ -216,7 +215,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self. assertTrue(mock <= 3)
         self. assertTrue(mock >= 3)
 
-        if not inPy3k:
+        if six.PY2:
             # incomparable in Python 3
             self.assertEqual(Mock() < 3, object() < 3)
             self.assertEqual(Mock() > 3, object() > 3)
@@ -294,7 +293,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         name = '__nonzero__'
         other = '__bool__'
-        if inPy3k:
+        if six.PY3:
             name, other = other, name
         getattr(mock, name).return_value = False
         self.assertFalse(hasattr(mock, other))
@@ -330,7 +329,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(unicode(mock), object.__str__(mock))
         self.assertIsInstance(unicode(mock), unicode)
         self.assertTrue(bool(mock))
-        if not inPy3k:
+        if six.PY2:
             self.assertEqual(oct(mock), '1')
         else:
             # in Python 3 oct and hex use __index__
@@ -340,7 +339,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         # how to test __sizeof__ ?
 
 
-    @unittest.skipIf(inPy3k, "no __cmp__ in Python 3")
+    @unittest.skipIf(six.PY3, "no __cmp__ in Python 3")
     def test_non_default_magic_methods(self):
         mock = MagicMock()
         self.assertRaises(AttributeError, lambda: mock.__cmp__)

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -4,9 +4,10 @@
 
 import unittest2 as unittest
 from mock.tests.support import (
-    callable, inPy3k, is_instance, next
+    callable, is_instance, next
 )
 
+import six
 import copy
 import pickle
 import sys
@@ -663,7 +664,7 @@ class MockTest(unittest.TestCase):
         copy.copy(Mock())
 
 
-    @unittest.skipIf(inPy3k, "no old style classes in Python 3")
+    @unittest.skipIf(six.PY3, "no old style classes in Python 3")
     def test_spec_old_style_classes(self):
         class Foo:
             bar = 7
@@ -677,7 +678,7 @@ class MockTest(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: mock.foo)
 
 
-    @unittest.skipIf(inPy3k, "no old style classes in Python 3")
+    @unittest.skipIf(six.PY3, "no old style classes in Python 3")
     def test_spec_set_old_style_classes(self):
         class Foo:
             bar = 7

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -4,11 +4,12 @@
 
 import os
 import sys
+import six
 
 import unittest2 as unittest
 
 from mock.tests import support
-from mock.tests.support import inPy3k, SomeClass, is_instance, callable
+from mock.tests.support import SomeClass, is_instance, callable
 
 from mock import (
     NonCallableMock, CallableMixin, patch, sentinel,
@@ -18,7 +19,7 @@ from mock import (
 from mock.mock import _patch, _get_target
 
 builtin_string = '__builtin__'
-if inPy3k:
+if six.PY3:
     builtin_string = 'builtins'
     unicode = str
 


### PR DESCRIPTION
This PR is taken out of #297 to replace the custom Python version detection with the one already provided by six.