### PR TITLE
Update six to a version with raises_from

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ funcsigs;python_version<"3.3"
 # but setuptools can't cope with conflicts in setup_requires, so thats
 # unversioned.
 pbr>=0.11
-six>=1.7
+six>=1.9


### PR DESCRIPTION
six.raises_from was introduced in six 1.9 [source](https://bitbucket.org/gutworth/six/src/cd1e81d33eaf3d6944f859c2aa7d5d3f515013c8/CHANGES?at=default&fileviewer=file-view-default#CHANGES-33). Since mock uses this [source](https://github.com/testing-cabal/mock/blob/7041095e3e8f0a8e15aeb671f879c01d7b3f9091/mock/mock.py#L934) we need to depend on 1.9, not 1.7 or else assert_called_once_with will throw "AttributeError: 'module' object has no attribute 'raise_from'"

As a side issue, shouldn't Travis have caught this?