### PR TITLE
Make mock_open support "for line in fh" iteration

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -2479,6 +2479,11 @@ def mock_open(mock=None, read_data=''):
         for line in _state[0]:
             yield line
 
+    def _iter_side_effect():
+        if handle.__iter__.return_value is not None:
+            return iter(handle.__iter__.return_value)
+        return _state[0]
+
 
     global file_spec
     if file_spec is None:
@@ -2501,11 +2506,13 @@ def mock_open(mock=None, read_data=''):
     handle.read.return_value = None
     handle.readline.return_value = None
     handle.readlines.return_value = None
+    handle.__iter__.return_value = None
 
     handle.read.side_effect = _read_side_effect
     _state[1] = _readline_side_effect()
     handle.readline.side_effect = _state[1]
     handle.readlines.side_effect = _readlines_side_effect
+    handle.__iter__.side_effect = _iter_side_effect
 
     def reset_data(*args, **kwargs):
         _state[0] = _iterate_read_data(read_data)

--- a/mock/tests/testwith.py
+++ b/mock/tests/testwith.py
@@ -228,6 +228,37 @@ class TestMockOpen(unittest.TestCase):
 
         self.assertEqual(result, ['foo\n', 'bar\n', 'baz'])
 
+    def test_iter_data(self):
+        # Test that emulating a file that ends in a newline character works
+        mock = mock_open(read_data='foo\nbar\nbaz\n')
+        expected = Mock(side_effect=['foo\n', 'bar\n', 'baz\n'])
+        with patch('%s.open' % __name__, mock, create=True):
+            h = open('bar')
+            for line in h:
+                self.assertEqual(line, expected())
+            self.assertEqual(expected.call_count, 3)
+
+        # Test that files without a final newline will also be correctly
+        # emulated
+        mock = mock_open(read_data='foo\nbar\nbaz')
+        expected = Mock(side_effect=['foo\n', 'bar\n', 'baz'])
+        with patch('%s.open' % __name__, mock, create=True):
+            h = open('bar')
+            for line in h:
+                self.assertEqual(line, expected())
+            self.assertEqual(expected.call_count, 3)
+
+        # Test that h.__iter__.return_value overrides default implementation
+        mock = mock_open(read_data='foo\nbar\nbaz\n')
+        override = ['FOO', 'BAR', 'BAZ']
+        expected = Mock(side_effect=override)
+        with patch('%s.open' % __name__, mock, create=True):
+            h = open('bar')
+            h.__iter__.return_value = override
+            for line in h:
+                self.assertEqual(line, expected())
+            self.assertEqual(expected.call_count, 3)
+
 
     def test_mock_open_read_with_argument(self):
         # At one point calling read with an argument was broken


### PR DESCRIPTION
File handles support direct iteration, but the result from `mock_open` currently just returns an empty iterator.