### PR TITLE
Add implicit dependency for `six`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@
 import setuptools
 
 setuptools.setup(
-    setup_requires=['pbr>=1.3', 'setuptools>=17.1'],
+    setup_requires=['pbr>=1.3', 'six>=1.7', 'setuptools>=17.1'],
     pbr=True)


### PR DESCRIPTION
`wraps` was added to `six` in the version `1.7`
