### PR TITLE
Fix #339: Add ChangeLog placeholder to fix symlink

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,3 @@
+This is a placeholder for our changelog symlink.
+
+Actual changes will appear here after build.

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -66,11 +66,14 @@ from types import ModuleType
 
 import six
 from six import wraps
-from pbr.version import VersionInfo
 
-_v = VersionInfo('mock').semantic_version()
-__version__ = _v.release_string()
-version_info = _v.version_tuple()
+# TODO(houglum): Adjust this section if we use a later version of mock.
+# Manually specify version so that we don't need to rely on pbr (which works
+# best when packages are installed via pip rather than direct download).
+# This allows us to include mock in other projects which can be installed
+# via methods other than pip (downloading a git repo, tarball, etc.).
+__version__ = '2.0.0'
+version_info = (2, 0, 0, 'final', 0)
 
 import mock
 


### PR DESCRIPTION
Running `python setup.py build_sphinx` will result in ChangeLog
being overwritten with actual changes.
