### PR TITLE
Blacklist __wrapped__ in `_Call`, to avoid infinite recursion

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -2209,6 +2209,11 @@ class _Call(tuple):
 
 
     def __getattr__(self, attr):
+        if attr == '__wrapped__':
+            raise AttributeError(
+                "__wrapped__ is blacklisted in 'call' to avoid recursion"
+                " (see Python bug #25532)"
+            )
         if self.name is None:
             return _Call(name=attr, from_kall=False)
         name = '%s.%s' % (self.name, attr)


### PR DESCRIPTION
When `inspect.unwrap` is run on `mock.call` (instance of class `_Call`, as `call = _Call(...)` in `mock.py`), it recursively looks up the `__wrapped__` attribute, which, in the case of a `_Call` instance, will lead to a `MemoryError` or (if memory is not limited) render the system unusable until kernel OOM.

`doctest.DocTestSuite` will use `inspect.unwrap` for all names in imported module scopes. This means that if an imported module has `mock.call` as module attribute (with, `from mock import call`, for example), running doctests on it will lead to infinite recursion. This is fixed by always raising `AttributeError` (with an explicit message) in `_Call.__getattr__`, if the name of the attribute being requested is `__wrapped__`.

This is tracked in the standard library (for `unittest.mock`) as [Issue 25532](https://bugs.python.org/issue25532)