### PR TITLE
Fix `DeprecationWarning` Exceptions when using mock in python 2.7 with `-3`

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -2057,6 +2057,8 @@ class _ANY(object):
     def __repr__(self):
         return '<ANY>'
 
+    __hash__ = None
+
 ANY = _ANY()
 
 
@@ -2199,6 +2201,7 @@ class _Call(tuple):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    __hash__ = None
 
     def __call__(self, *args, **kwargs):
         if self.name is None:


### PR DESCRIPTION
I am investigating a migration to Python 3, and to facilitate this we are using the -3 flag as decribed here: https://docs.python.org/3/howto/pyporting.html#prevent-compatibility-regressions . When using this flag I encountered
some issues inside of mock itself.

Python 3 now requires you to implement `__hash__` if you implement `__eq__`. See https://docs.python.org/3.6/reference/datamodel.html#object.%5F%5Fhash%5F%5F .

```python
{mock.ANY}  # Fine in Python 2, Throws in Python 3
```

This PR explicitly sets the `__hash__` method on these objects as `None` to ensure the behavior is consistent in Python 3 as well as Python 2.