### PR TITLE
Fix autospec's behavior on method-bound builtin functions

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -280,7 +280,7 @@ def _set_signature(mock, original, instance=False):
     skipfirst = isinstance(original, ClassTypes)
     result = _get_signature_object(original, instance, skipfirst)
     if result is None:
-        return
+        return mock
     func, sig = result
     def checksig(*args, **kwargs):
         sig.bind(*args, **kwargs)

--- a/mock/tests/testhelpers.py
+++ b/mock/tests/testhelpers.py
@@ -3,6 +3,7 @@
 # http://www.voidspace.org.uk/python/mock/
 
 import six
+import time
 import unittest
 
 from mock import (
@@ -884,6 +885,18 @@ class SpecSignatureTest(unittest.TestCase):
         mock_slot.abc(4, 5, 6)
         mock_slot.assert_called_once_with(1, 2, 3)
         mock_slot.abc.assert_called_once_with(4, 5, 6)
+
+    def test_autospec_on_bound_builtin_function(self):
+        meth = six.create_bound_method(time.ctime, time.time())
+        self.assertIsInstance(meth(), str)
+        mocked = create_autospec(meth)
+
+        # no signature, so no spec to check against
+        mocked()
+        mocked.assert_called_once_with()
+        mocked.reset_mock()
+        mocked(4, 5, 6)
+        mocked.assert_called_once_with(4, 5, 6)
 
 
 class TestCallList(unittest.TestCase):


### PR DESCRIPTION
>Cython will, in the right circumstances, offer a MethodType instance where im_func is a builtin function. Any instance of MethodType is automatically assumed to be a python-defined function (more specifically, a function that has an inspectable signature), but _set_signature was still conservative in its assumptions. As a result _set_signature would return early with None instead of a mock since the im_func had no inspectable signature. This causes problems deeper inside mock, as _set_signature is assumed to _always_ return a mock, and nothing checked its return value.
>
>In similar corner cases, autospec will simply not check the spec of the function, so _set_signature is amended to now return early with the original, not-wrapped mock object.
