### PR TITLE
Adds signature checking for mock spec object method calls

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -210,6 +210,8 @@ def _check_signature(func, mock, skipfirst, instance=False):
     _copy_func_details(func, checksig)
     type(mock)._mock_check_sig = checksig
 
+    return sig
+
 
 def _copy_func_details(func, funcopy):
     funcopy.__name__ = func.__name__
@@ -497,7 +499,8 @@ class NonCallableMock(Base):
     def __init__(
             self, spec=None, wraps=None, name=None, spec_set=None,
             parent=None, _spec_state=None, _new_name='', _new_parent=None,
-            _spec_as_instance=False, _eat_self=None, unsafe=False, **kwargs
+            _spec_as_instance=False, _eat_self=None, unsafe=False,
+            autospec=None, **kwargs
         ):
         if _new_parent is None:
             _new_parent = parent
@@ -507,10 +510,15 @@ class NonCallableMock(Base):
         __dict__['_mock_name'] = name
         __dict__['_mock_new_name'] = _new_name
         __dict__['_mock_new_parent'] = _new_parent
+        __dict__['_autospec'] = autospec
 
         if spec_set is not None:
             spec = spec_set
             spec_set = True
+        if autospec is not None:
+            # autospec is even stricter than spec_set.
+            spec = autospec
+            autospec = True
         if _eat_self is None:
             _eat_self = parent is not None
 
@@ -551,12 +559,18 @@ class NonCallableMock(Base):
         setattr(self, attribute, mock)
 
 
-    def mock_add_spec(self, spec, spec_set=False):
+    def mock_add_spec(self, spec, spec_set=False, autospec=None):
         """Add a spec to a mock. `spec` can either be an object or a
         list of strings. Only attributes on the `spec` can be fetched as
         attributes from the mock.
 
-        If `spec_set` is True then only attributes on the spec can be set."""
+        If `spec_set` is True then only attributes on the spec can be set.
+        If `autospec` is True then only attributes on the spec can be accessed
+        and set, and if a method in the `spec` is called, it's signature is
+        checked.
+        """
+        if autospec is not None:
+            self.__dict__['_autospec'] = autospec
         self._mock_add_spec(spec, spec_set)
 
 
@@ -570,9 +584,9 @@ class NonCallableMock(Base):
                 _spec_class = spec
             else:
                 _spec_class = _get_class(spec)
-            res = _get_signature_object(spec,
-                                        _spec_as_instance, _eat_self)
-            _spec_signature = res and res[1]
+
+            _spec_signature = _check_signature(spec, self, _eat_self,
+                                               _spec_as_instance)
 
             spec = dir(spec)
 
@@ -712,9 +726,20 @@ class NonCallableMock(Base):
                 # execution?
                 wraps = getattr(self._mock_wraps, name)
 
+            kwargs = {}
+            if self.__dict__.get('_autospec') is not None:
+                # get the mock's spec attribute with the same name and
+                # pass it to the child.
+                spec_class = self.__dict__.get('_spec_class')
+                spec = getattr(spec_class, name, None)
+                is_type = isinstance(spec_class, ClassTypes)
+                eat_self = _must_skip(spec_class, name, is_type)
+                kwargs['_eat_self'] = eat_self
+                kwargs['autospec'] = spec
+
             result = self._get_child_mock(
                 parent=self, name=name, wraps=wraps, _new_name=name,
-                _new_parent=self
+                _new_parent=self, **kwargs
             )
             self._mock_children[name]  = result
 

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -510,6 +510,48 @@ class MockTest(unittest.TestCase):
                 )
 
 
+    def _check_autospeced_something(self, something):
+        for method_name in ['meth', 'cmeth', 'smeth']:
+            mock_method = getattr(something, method_name)
+
+            # check that the methods are callable with correct args.
+            mock_method(sentinel.a, sentinel.b, sentinel.c)
+            mock_method(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)
+            mock_method.assert_has_calls([
+                call(sentinel.a, sentinel.b, sentinel.c),
+                call(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)])
+
+            # assert that TypeError is raised if the method signature is not
+            # respected.
+            self.assertRaises(TypeError, mock_method)
+            self.assertRaises(TypeError, mock_method, sentinel.a)
+            self.assertRaises(TypeError, mock_method, a=sentinel.a)
+            self.assertRaises(TypeError, mock_method, sentinel.a, sentinel.b,
+                              sentinel.c, e=sentinel.e)
+
+        # assert that AttributeError is raised if the method does not exist.
+        self.assertRaises(AttributeError, getattr, something, 'foolish')
+
+
+    def test_mock_autospec_all_members(self):
+        for spec in [Something, Something()]:
+            mock_something = Mock(autospec=spec)
+            self._check_autospeced_something(mock_something)
+
+
+    def test_mock_spec_function(self):
+        def foo(lish):
+            pass
+
+        mock_foo = Mock(spec=foo)
+
+        mock_foo(sentinel.lish)
+        mock_foo.assert_called_once_with(sentinel.lish)
+        self.assertRaises(TypeError, mock_foo)
+        self.assertRaises(TypeError, mock_foo, sentinel.foo, sentinel.lish)
+        self.assertRaises(TypeError, mock_foo, foo=sentinel.foo)
+
+
     def test_from_spec(self):
         class Something(object):
             x = 3
@@ -1396,6 +1438,13 @@ class MockTest(unittest.TestCase):
             self.assertRaises(TypeError, lambda: mock['foo'])
 
 
+    def test_mock_add_spec_autospec_all_members(self):
+        for spec in [Something, Something()]:
+            mock_something = Mock()
+            mock_something.mock_add_spec(spec, autospec=True)
+            self._check_autospeced_something(mock_something)
+
+
     def test_adding_child_mock(self):
         for Klass in NonCallableMock, Mock, MagicMock, NonCallableMagicMock:
             mock = Klass()
@@ -1484,8 +1533,8 @@ class MockTest(unittest.TestCase):
     def test_mock_open_alter_readline(self):
         mopen = mock.mock_open(read_data='foo\nbarn')
         mopen.return_value.readline.side_effect = lambda *args:'abc'
-        first = mopen().readline()
-        second = mopen().readline()
+        first = mopen('foo.lish').readline()
+        second = mopen('bar.tender').readline()
         self.assertEqual('abc', first)
         self.assertEqual('abc', second)
  

--- a/mock/tests/testwith.py
+++ b/mock/tests/testwith.py
@@ -262,7 +262,7 @@ class TestMockOpen(unittest.TestCase):
         # for mocks returned by mock_open
         some_data = 'foo\nbar\nbaz'
         mock = mock_open(read_data=some_data)
-        self.assertEqual(mock().read(10), some_data)
+        self.assertEqual(mock('foo.lish').read(10), some_data)
 
 
     def test_interleaved_reads(self):
@@ -287,7 +287,7 @@ class TestMockOpen(unittest.TestCase):
 
     def test_overriding_return_values(self):
         mock = mock_open(read_data='foo')
-        handle = mock()
+        handle = mock('foo.lish')
 
         handle.read.return_value = 'bar'
         handle.readline.return_value = 'bar'


### PR DESCRIPTION
Mock can accept a spec object / class as argument, making sure that
accessing attributes that do not exist in the spec will cause an
AttributeError to be raised, but there is no guarantee that the spec's
methods signatures are respected in any way. This creates the possibility
to have faulty code with passing unittests and assertions.

Passes the spec's attribute with the same name to the child mock (spec-ing
the child).
Sets _mock_check_sig if the given spec is callable.
Adds unit tests to validate the fact that the spec method signatures are
respected.