### PR TITLE
Drop support for EOL Python <= 2.6 & 3.0-3.2, add 3.5 & 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
   - pypy
   - pypy3
 matrix:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ mock is now part of the Python standard library, available as `unittest.mock
 onwards.
 
 This package contains a rolling backport of the standard library mock code
-compatible with Python 2.6 and up, and 3.3 and up.
+compatible with Python 2.7 and 3.3 and up.
 
 Please see the standard library documentation for more details.
 
@@ -17,7 +17,7 @@ Please see the standard library documentation for more details.
 :License: `BSD License`_
 :Support: `Mailing list (testing-in-python@lists.idyll.org)
  <http://lists.idyll.org/listinfo/testing-in-python>`_
-:Issue tracker: `Github Issues
+:Issue tracker: `GitHub Issues
  <https://github.com/testing-cabal/mock/issues>`_
 :Build status:
   .. image:: https://travis-ci.org/testing-cabal/mock.svg?branch=master

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -10,7 +10,7 @@
 :License: `BSD License`_
 :Support: `Mailing list (testing-in-python@lists.idyll.org)
  <http://lists.idyll.org/listinfo/testing-in-python>`_
-:Issue tracker: `Github Issues
+:Issue tracker: `GitHub Issues
  <https://github.com/testing-cabal/mock/issues>`_
 :Last sync: cb6aab1248c4aec4dd578bea717854505a6fb55d
 
@@ -45,9 +45,12 @@ the newest features from the latest release of Python available for all
 Pythons.
 
 The ``mock`` package contains a rolling backport of the standard library mock
-code compatible with Python 2.6 and up, and 3.3 and up. Python 3.2 is supported
-by mock 1.3.0 and below - with pip no longer supporting 3.2, we cannot test
-against that version anymore.
+code compatible with Python 2.7 and 3.3 and up.
+
+* Python 2.6 is supported by mock 2.0.0 and below.
+
+* Python 3.2 is supported by mock 1.3.0 and below - with pip no longer
+supporting 3.2, we cannot test against that version anymore.
 
 Please see the standard library documentation for usage details.
 
@@ -64,7 +67,7 @@ The current version is |release|. Mock is stable and widely used.
 .. index:: repository
 .. index:: git
 
-You can checkout the latest development version from Github
+You can checkout the latest development version from GitHub
 repository with the following command:
 
     ``git clone https://github.com/testing-cabal/mock``
@@ -110,6 +113,8 @@ Older Versions of Python
 
 Version 1.0.1 is the last version compatible with Python < 2.6.
 
+Version 2.0.0 is the last version compatible with Python 2.6.
+
 .. index:: maintainer notes
 
 Maintainer Notes
@@ -123,7 +128,7 @@ Checkout from git (see :ref:`installing`) and submit pull requests.
 Committers can just push as desired: since all semantic development takes
 place in cPython, the backport process is as lightweight as we can make it.
 
-mock is CI tested using Travis-CI on Python versions 2.6, 2.7, 3.3, 3.4,
+mock is CI tested using Travis-CI on Python versions 2.7, 3.3, 3.4,
 3.5, nightly Python 3 builds, pypy, pypy3. Jython support is desired, if
 someone could contribute a patch to .travis.yml to support it that would be
 excellent.

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -94,12 +94,6 @@ except NameError:
     # Python 3
     long = int
 
-try:
-    BaseException
-except NameError:
-    # Python 2.4 compatibility
-    BaseException = Exception
-
 if six.PY2:
     # Python 2's next() can't handle a non-iterator with a __next__ method.
     _next = next

--- a/mock/tests/support.py
+++ b/mock/tests/support.py
@@ -1,19 +1,3 @@
-import sys
-
-info = sys.version_info
-import unittest2
-
-
-try:
-    callable = callable
-except NameError:
-    def callable(obj):
-        return hasattr(obj, '__call__')
-
-
-with_available = sys.version_info[:2] >= (2, 5)
-
-
 def is_instance(obj, klass):
     """Version of is_instance that doesn't access __class__"""
     return issubclass(type(obj), klass)
@@ -28,9 +12,3 @@ class SomeClass(object):
 
 class X(object):
     pass
-
-try:
-    next = next
-except NameError:
-    def next(obj):
-        return obj.next()

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -18,9 +18,7 @@ from mock import (
     create_autospec
 )
 from mock.mock import _CallList
-from mock.tests.support import (
-    callable, is_instance, next
-)
+from mock.tests.support import is_instance
 
 
 try:
@@ -738,7 +736,7 @@ class MockTest(unittest.TestCase):
     def test_dir(self):
         mock = Mock()
         attrs = set(dir(mock))
-        type_attrs = set([m for m in dir(Mock) if not m.startswith('_')])
+        type_attrs = {m for m in dir(Mock) if not m.startswith('_')}
 
         # all public attributes from the type are included
         self.assertEqual(set(), type_attrs - attrs)

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -9,7 +9,7 @@ import six
 import unittest2 as unittest
 
 from mock.tests import support
-from mock.tests.support import SomeClass, is_instance, callable
+from mock.tests.support import SomeClass, is_instance
 
 from mock import (
     NonCallableMock, CallableMixin, patch, sentinel,
@@ -1340,7 +1340,7 @@ class PatchTest(unittest.TestCase):
         try:
             f = result['f']
             foo = result['foo']
-            self.assertEqual(set(result), set(['f', 'foo']))
+            self.assertEqual(set(result), {'f', 'foo'})
 
             self.assertIs(Foo, original_foo)
             self.assertIs(Foo.f, f)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,12 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.2
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: Jython
     Programming Language :: Python :: Implementation :: PyPy
@@ -33,10 +32,7 @@ keyword =
 test =
   unittest2>=1.1.0
 docs =
-  jinja2<2.7:python_version<"3.3" and python_version>="3"
-  Pygments<2:python_version<"3.3" and python_version>="3"
-  sphinx<1.3:python_version<"3.3" and python_version>="3"
-  sphinx:python_version<"3" or python_version>="3.3"
+  sphinx
 
 [files]
 packages = mock

--- a/tools/pre-applypatch
+++ b/tools/pre-applypatch
@@ -26,7 +26,6 @@ function test_version {
 
 find . -name "*.pyc" -exec rm "{}" \;
 
-test_version 2.6
 test_version 2.7
 test_version 3.3
 test_version 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,9 @@
 [tox]
-envlist = py25,py26,py27,py31,pypy,py32,py33,jython
+envlist = py27,pypy,py33,jython
 
 [testenv]
 deps=unittest2
 commands={envbindir}/unit2 discover []
-
-[testenv:py26]
-commands=
-    {envbindir}/unit2 discover []
-    {envbindir}/sphinx-build -E -b doctest docs html
-    {envbindir}/sphinx-build -E docs html
-deps =
-    unittest2
-    sphinx
 
 [testenv:py27]
 commands=
@@ -21,15 +12,6 @@ commands=
 deps =
     unittest2
     sphinx
-
-[testenv:py31]
-deps =
-    unittest2py3k
-
-[testenv:py32]
-commands=
-    {envbindir}/python -m unittest discover []
-deps =
 
 [testenv:py33]
 commands=


### PR DESCRIPTION
Fixes https://github.com/testing-cabal/mock/issues/409 by dropping 2.6.

3.0 - 3.2 were already dropped, this removes some old code.

And 3.5 and 3.6 are now tested.

Here's the pip installs for mock from PyPI for the last month:
```
$ pypinfo --percent --pip mock pyversion
python_version percent download_count
-------------- ------- --------------
2.7              84.1%      1,803,326
3.6               5.8%        124,000
3.5               5.0%        107,146
3.4               2.9%         62,454
2.6               2.1%         45,236
3.3               0.1%          2,329
3.7               0.0%            475
None              0.0%             22
3.2               0.0%             15

```
