### PR TITLE
Fix assert_xxx methods on autospec functions

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -306,6 +306,12 @@ def _setup_func(funcopy, mock):
     if not _is_instance_mock(mock):
         return
 
+    def assert_called(*args, **kwargs):
+        return mock.assert_called(*args, **kwargs)
+    def assert_not_called(*args, **kwargs):
+        return mock.assert_not_called(*args, **kwargs)
+    def assert_called_once(*args, **kwargs):
+        return mock.assert_called_once(*args, **kwargs)
     def assert_called_with(*args, **kwargs):
         return mock.assert_called_with(*args, **kwargs)
     def assert_called_once_with(*args, **kwargs):
@@ -338,6 +344,9 @@ def _setup_func(funcopy, mock):
     funcopy.assert_has_calls = assert_has_calls
     funcopy.assert_any_call = assert_any_call
     funcopy.reset_mock = reset_mock
+    funcopy.assert_called = assert_called
+    funcopy.assert_not_called = assert_not_called
+    funcopy.assert_called_once = assert_called_once
 
     mock._mock_delegate = funcopy
 

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -974,8 +974,14 @@ class PatchTest(unittest.TestCase):
     def test_autospec_function(self):
         @patch('%s.function' % __name__, autospec=True)
         def test(mock):
+            function.assert_not_called()
+            self.assertRaises(AssertionError, function.assert_called)
+            self.assertRaises(AssertionError, function.assert_called_once)
             function(1)
+            self.assertRaises(AssertionError, function.assert_not_called)
             function.assert_called_with(1)
+            function.assert_called()
+            function.assert_called_once()
             function(2, 3)
             function.assert_called_with(2, 3)
 


### PR DESCRIPTION
Add functions assert_called, assert_not_called, and assert_called_once to functions when using autospec.

Fixes #398 

This was fixed in upstream a while ago, but it looks like it never made it here:
https://bugs.python.org/issue28380
https://github.com/python/cpython/commit/ac5084b6c760ff5e6469854373fe6c3c81804f87#diff-ff75b1b83c21770847ade91fa5bb2525
