### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ mock is now part of the Python standard library, available as `unittest.mock
 onwards.
 
 This package contains a rolling backport of the standard library mock code
-compatible with Python 2.7 and 3.3 and up.
+compatible with Python 2.7 and 3.4 and up.
 
 Please see the standard library documentation for more details.
 
@@ -24,6 +24,6 @@ Please see the standard library documentation for more details.
       :target: https://travis-ci.org/testing-cabal/mock
 
 .. _Mock Homepage: https://github.com/testing-cabal/mock
-.. _BSD License: http://github.com/testing-cabal/mock/blob/master/LICENSE.txt
+.. _BSD License: https://github.com/testing-cabal/mock/blob/master/LICENSE.txt
 .. _Python Docs: https://docs.python.org/dev/library/unittest.mock.html
 .. _mock on PyPI: http://pypi.python.org/pypi/mock

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -45,9 +45,9 @@ the newest features from the latest release of Python available for all
 Pythons.
 
 The ``mock`` package contains a rolling backport of the standard library mock
-code compatible with Python 2.7 and 3.3 and up.
+code compatible with Python 2.7 and 3.4 and up.
 
-* Python 2.6 is supported by mock 2.0.0 and below.
+* Python 2.6 and 3.3 are supported by mock 2.0.0 and below.
 
 * Python 3.2 is supported by mock 1.3.0 and below - with pip no longer
 supporting 3.2, we cannot test against that version anymore.
@@ -128,8 +128,8 @@ Checkout from git (see :ref:`installing`) and submit pull requests.
 Committers can just push as desired: since all semantic development takes
 place in cPython, the backport process is as lightweight as we can make it.
 
-mock is CI tested using Travis-CI on Python versions 2.7, 3.3, 3.4,
-3.5, nightly Python 3 builds, pypy, pypy3. Jython support is desired, if
+mock is CI tested using Travis-CI on Python versions 2.7, 3.4,
+3.5, 3.6, nightly Python 3 builds, pypy, pypy3. Jython support is desired, if
 someone could contribute a patch to .travis.yml to support it that would be
 excellent.
 

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -105,7 +105,7 @@ if six.PY2:
     del _next
 
 
-_builtins = set(name for name in dir(builtins) if not name.startswith('_'))
+_builtins = {name for name in dir(builtins) if not name.startswith('_')}
 
 BaseExceptions = (BaseException,)
 if 'java' in sys.platform:
@@ -389,11 +389,11 @@ ClassTypes = (type,)
 if six.PY2:
     ClassTypes = (type, ClassType)
 
-_allowed_names = set((
+_allowed_names = {
     'return_value', '_mock_return_value', 'side_effect',
     '_mock_side_effect', '_mock_parent', '_mock_new_parent',
     '_mock_name', '_mock_new_name'
-))
+}
 
 
 def _delegating_property(name):
@@ -764,7 +764,7 @@ class NonCallableMock(Base):
             if self._spec_set:
                 spec_string = ' spec_set=%r'
             spec_string = spec_string % self._spec_class.__name__
-        return "<%s%s%s id='%s'>" % (
+        return "<{}{}{} id='{}'>".format(
             type(self).__name__,
             name_string,
             spec_string,
@@ -916,13 +916,13 @@ class NonCallableMock(Base):
         self = _mock_self
         if self.call_args is None:
             expected = self._format_mock_call_signature(args, kwargs)
-            raise AssertionError('Expected call: %s\nNot called' % (expected,))
+            raise AssertionError('Expected call: {}\nNot called'.format(expected))
 
         def _error_message(cause):
             msg = self._format_mock_failure_message(args, kwargs)
             if six.PY2 and cause is not None:
                 # Tack on some diagnostics for Python without __cause__
-                msg = '%s\n%s' % (msg, str(cause))
+                msg = '{}\n{}'.format(msg, str(cause))
             return msg
         expected = self._call_matcher((args, kwargs))
         actual = self._call_matcher(self.call_args)
@@ -973,7 +973,7 @@ class NonCallableMock(Base):
                 not_found.append(kall)
         if not_found:
             six.raise_from(AssertionError(
-                '%r not all found in call list' % (tuple(not_found),)
+                '{!r} not all found in call list'.format(tuple(not_found))
             ), cause)
 
 
@@ -1334,7 +1334,7 @@ class _patch(object):
 
         if not self.create and original is DEFAULT:
             raise AttributeError(
-                "%s does not have the attribute %r" % (target, name)
+                "{} does not have the attribute {!r}".format(target, name)
             )
         return original, local
 
@@ -1837,13 +1837,13 @@ else:
 # (as they are metaclass methods)
 # __del__ is not supported at all as it causes problems if it exists
 
-_non_defaults = set((
+_non_defaults = {
     '__cmp__', '__getslice__', '__setslice__', '__coerce__', # <3.x
     '__get__', '__set__', '__delete__', '__reversed__', '__missing__',
     '__reduce__', '__reduce_ex__', '__getinitargs__', '__getnewargs__',
     '__getstate__', '__setstate__', '__getformat__', '__setformat__',
     '__repr__', '__dir__', '__subclasses__', '__format__',
-))
+}
 
 
 def _get_method(name, func):
@@ -1854,19 +1854,19 @@ def _get_method(name, func):
     return method
 
 
-_magics = set(
+_magics = {
     '__%s__' % method for method in
     ' '.join([magic_methods, numerics, inplace, right, extra]).split()
-)
+}
 
 _all_magics = _magics | _non_defaults
 
-_unsupported_magics = set((
+_unsupported_magics = {
     '__getattr__', '__setattr__',
     '__init__', '__new__', '__prepare__'
     '__instancecheck__', '__subclasscheck__',
     '__del__'
-))
+}
 
 _calculate_return_value = {
     '__hash__': lambda self: object.__hash__(self),
@@ -2069,7 +2069,7 @@ def _format_call_signature(name, args, kwargs):
             return item
 
     kwargs_string = ', '.join([
-        '%s=%r' % (encode_item(key), value) for key, value in sorted(kwargs.items())
+        '{}={!r}'.format(encode_item(key), value) for key, value in sorted(kwargs.items())
     ])
     if args_string:
         formatted_args = args_string
@@ -2208,7 +2208,7 @@ class _Call(tuple):
     def __getattr__(self, attr):
         if self.name is None:
             return _Call(name=attr, from_kall=False)
-        name = '%s.%s' % (self.name, attr)
+        name = '{}.{}'.format(self.name, attr)
         return _Call(name=name, parent=self, from_kall=False)
 
 

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -811,7 +811,7 @@ class MockTest(unittest.TestCase):
             instance = sys.exc_info()[1]
             self.assertIsInstance(instance, exception)
         else:
-            self.fail('Exception %r not raised' % (exception,))
+            self.fail('Exception {!r} not raised'.format(exception))
 
         msg = str(instance)
         self.assertEqual(msg, message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr>=1.3', 'setuptools>=17.1'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     pbr=True)

--- a/tools/pre-applypatch
+++ b/tools/pre-applypatch
@@ -27,7 +27,6 @@ function test_version {
 find . -name "*.pyc" -exec rm "{}" \;
 
 test_version 2.7
-test_version 3.3
 test_version 3.4
 test_version 3.5
 test_version cpython

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,jython
+envlist = py27,pypy,jython
 
 [testenv]
 deps=unittest2


### PR DESCRIPTION
Python 3.3 is failing the build.

It's also EOL and no longer receiving security updates (or any updates) from the core Python team.

And it's also little used. Here's the pip installs for mock from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  81.27% |      1,155,290 |
| 3.6            |   8.72% |        124,026 |
| 3.5            |   4.89% |         69,533 |
| 3.4            |   4.10% |         58,272 |
| 2.6            |   0.89% |         12,621 |
| 3.3            |   0.08% |          1,139 |
| 3.7            |   0.04% |            600 |
| 3.8            |   0.00% |             22 |
| 3.2            |   0.00% |             10 |
| None           |   0.00% |              4 |