### PR TITLE
Fix tests/drop 2.6-compat via unittest2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ import os
 import sys
 import mock
 from mock import * # yeah, I know :-/
-import unittest2
+import unittest
 import __main__
 
 if os.getcwd() not in sys.path:

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -90,7 +90,6 @@ unpacking run:
 Bug Reports
 +++++++++++
 
-Mock uses `unittest2 <http://pypi.python.org/pypi/unittest2>`_ for its own
 Issues with the backport process, such as compatibility with a particular
 Python, should be reported to the `bug tracker
 <https://github.com/testing-cabal/mock/issues>`_. Feature requests and issues

--- a/mock/tests/testcallable.py
+++ b/mock/tests/testcallable.py
@@ -2,7 +2,7 @@
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
 # http://www.voidspace.org.uk/python/mock/
 
-import unittest2 as unittest
+import unittest
 from mock.tests.support import is_instance, X, SomeClass
 
 from mock import (

--- a/mock/tests/testhelpers.py
+++ b/mock/tests/testhelpers.py
@@ -3,7 +3,7 @@
 # http://www.voidspace.org.uk/python/mock/
 
 import six
-import unittest2 as unittest
+import unittest
 
 from mock import (
     call, create_autospec, MagicMock,

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -16,7 +16,7 @@ import sys
 import textwrap
 
 import six
-import unittest2 as unittest
+import unittest
 
 from mock import Mock, MagicMock
 from mock.mock import _magics

--- a/mock/tests/testmagicmethods.py
+++ b/mock/tests/testmagicmethods.py
@@ -405,7 +405,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock = MagicMock()
         def set_setattr():
             mock.__setattr__ = lambda self, name: None
-        self.assertRaisesRegex(AttributeError,
+        six.assertRaisesRegex(self, AttributeError,
             "Attempting to set unsupported magic method '__setattr__'.",
             set_setattr
         )

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 
 import six
-import unittest2 as unittest
+import unittest
 
 import mock
 from mock import (

--- a/mock/tests/testmock.py
+++ b/mock/tests/testmock.py
@@ -205,7 +205,7 @@ class MockTest(unittest.TestCase):
 
         mock = create_autospec(f)
         mock.side_effect = ValueError('Bazinga!')
-        self.assertRaisesRegex(ValueError, 'Bazinga!', mock)
+        six.assertRaisesRegex(self, ValueError, 'Bazinga!', mock)
 
     @unittest.skipUnless('java' in sys.platform,
                           'This test only applies to Jython')
@@ -501,7 +501,8 @@ class MockTest(unittest.TestCase):
 
                 # this should be allowed
                 mock.something
-                self.assertRaisesRegex(
+                six.assertRaisesRegex(
+                    self,
                     AttributeError,
                     "Mock object has no attribute 'something_else'",
                     getattr, mock, 'something_else'
@@ -520,12 +521,14 @@ class MockTest(unittest.TestCase):
             mock.x
             mock.y
             mock.__something__
-            self.assertRaisesRegex(
+            six.assertRaisesRegex(
+                self,
                 AttributeError,
                 "Mock object has no attribute 'z'",
                 getattr, mock, 'z'
             )
-            self.assertRaisesRegex(
+            six.assertRaisesRegex(
+                self,
                 AttributeError,
                 "Mock object has no attribute '__foobar__'",
                 getattr, mock, '__foobar__'
@@ -591,13 +594,13 @@ class MockTest(unittest.TestCase):
 
     def test_assert_called_with_message(self):
         mock = Mock()
-        self.assertRaisesRegex(AssertionError, 'Not called',
+        six.assertRaisesRegex(self, AssertionError, 'Not called',
                                 mock.assert_called_with)
 
 
     def test_assert_called_once_with_message(self):
         mock = Mock(name='geoffrey')
-        self.assertRaisesRegex(AssertionError,
+        six.assertRaisesRegex(self, AssertionError,
                      r"Expected 'geoffrey' to be called once\.",
                      mock.assert_called_once_with)
 
@@ -1486,7 +1489,7 @@ class MockTest(unittest.TestCase):
         second = mopen().readline()
         self.assertEqual('abc', first)
         self.assertEqual('abc', second)
- 
+
     def test_mock_parents(self):
         for Klass in Mock, MagicMock:
             m = Klass()

--- a/mock/tests/testpatch.py
+++ b/mock/tests/testpatch.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 import six
-import unittest2 as unittest
+import unittest
 
 from mock.tests import support
 from mock.tests.support import SomeClass, is_instance

--- a/mock/tests/testsentinel.py
+++ b/mock/tests/testsentinel.py
@@ -2,7 +2,7 @@
 # E-mail: fuzzyman AT voidspace DOT org DOT uk
 # http://www.voidspace.org.uk/python/mock/
 
-import unittest2 as unittest
+import unittest
 
 from mock import sentinel, DEFAULT
 

--- a/mock/tests/testwith.py
+++ b/mock/tests/testwith.py
@@ -4,7 +4,7 @@
 
 from warnings import catch_warnings
 
-import unittest2 as unittest
+import unittest
 
 from mock.tests.support import is_instance
 from mock import MagicMock, Mock, patch, sentinel, mock_open, call

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ home-page = https://github.com/testing-cabal/mock
 description-file = README.rst
 author = Testing Cabal
 author-email = testing-in-python@lists.idyll.org
-classifier = 
+classifier =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers
@@ -29,8 +29,6 @@ keyword =
     testing, test, mock, mocking, unittest, patching, stubs, fakes, doubles
 
 [extras]
-test =
-  unittest2>=1.1.0
 docs =
   sphinx
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,13 @@
 envlist = py27,pypy,py33,jython
 
 [testenv]
-deps=unittest2
-commands={envbindir}/unit2 discover []
+commands=python -m unittest discover []
 
 [testenv:py27]
 commands=
-    {envbindir}/unit2 discover []
+    python -m unittest discover []
     {envbindir}/sphinx-build -E -b doctest docs html
 deps =
-    unittest2
     sphinx
 
 [testenv:py33]

--- a/unittest.cfg
+++ b/unittest.cfg
@@ -1,18 +1,18 @@
 
 [unittest]
 plugins = 
-    unittest2.plugins.debugger
-    unittest2.plugins.checker
-    unittest2.plugins.doctestloader
-    unittest2.plugins.matchregexp
-    unittest2.plugins.moduleloading
-    unittest2.plugins.testcoverage
-    unittest2.plugins.growl
-    unittest2.plugins.filtertests
-    unittest2.plugins.junitxml
-    unittest2.plugins.timed
-    unittest2.plugins.counttests
-    unittest2.plugins.logchannels
+    unittest.plugins.debugger
+    unittest.plugins.checker
+    unittest.plugins.doctestloader
+    unittest.plugins.matchregexp
+    unittest.plugins.moduleloading
+    unittest.plugins.testcoverage
+    unittest.plugins.growl
+    unittest.plugins.filtertests
+    unittest.plugins.junitxml
+    unittest.plugins.timed
+    unittest.plugins.counttests
+    unittest.plugins.logchannels
 
 excluded-plugins =
 


### PR DESCRIPTION
Found these issues while looking at the Arch Linux package. We don't provide a pointless unittest2 module for python3, so the testsuites either fail on python3 without using sed to use unittest instead, or fail on python 2.7 because unittest almost-but-not-quite works everywhere.