### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,6 +1,6 @@
-====================================
+===================================
  Mock - Mocking and Testing Library
-====================================
+===================================
 
 :Version: |release|
 :Date: |today|
@@ -50,7 +50,7 @@ code compatible with Python 2.7 and 3.3 and up.
 * Python 2.6 is supported by mock 2.0.0 and below.
 
 * Python 3.2 is supported by mock 1.3.0 and below - with pip no longer
-supporting 3.2, we cannot test against that version anymore.
+  supporting 3.2, we cannot test against that version anymore.
 
 Please see the standard library documentation for usage details.
 
@@ -121,7 +121,7 @@ Maintainer Notes
 ++++++++++++++++
 
 Development
-===========
+-----------
 
 Checkout from git (see :ref:`installing`) and submit pull requests.
 
@@ -134,7 +134,7 @@ someone could contribute a patch to .travis.yml to support it that would be
 excellent.
 
 Releasing
-=========
+---------
 
 NB: please use semver. Bump the major component on API breaks, minor on all
 non-bugfix changes, patch on bugfix only changes.
@@ -144,13 +144,13 @@ non-bugfix changes, patch on bugfix only changes.
 
 
 Backporting rules
-=================
+-----------------
 
 isinstance checks in cPython to ``type`` need to check ``ClassTypes``.
 Code calling ``obj.isidentifier`` needs to change to ``_isidentifier(obj)``.
 
 Backporting process
-===================
+-------------------
 
 1. Patch your git am with `my patch <https://github.com/rbtcollins/git>`_.
 2. Install the applypatch-transform hook from tools/ to your .git hooks dir.


### PR DESCRIPTION
Warnings previously appeared as:

```
  mock/docs/index.txt:53: WARNING: Bullet list ends without a blank line; unexpected unindent.

  mock/docs/index.txt:123: WARNING: Title level inconsistent:
```