### PR TITLE
Simplify tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,12 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37jython
+envlist = py27,pypy,py34,py35,py36,py37jython,docs
 
 [testenv]
-commands={envbindir}/python -m unittest discover []
+commands =
+    {envbindir}/python -m unittest discover {posargs}
 
-[testenv:py27]
-commands=
-    {envbindir}/python -m unittest discover []
-    {envbindir}/sphinx-build -E -b doctest docs html
+[testenv:docs]
 deps =
     sphinx
-
-[testenv:py34]
-commands=
-    {envbindir}/python -m unittest discover []
-deps =
-
-[testenv:py35]
-commands=
-    {envbindir}/python -m unittest discover []
-deps =
-
-[testenv:py36]
-commands=
-    {envbindir}/python -m unittest discover []
-deps =
-
-[testenv:py37]
-commands=
-    {envbindir}/python -m unittest discover []
-deps =
-
-# note for jython. Execute in tests directory:
-# rm `find . -name '*$py.class'`
+commands =
+    {envbindir}/python setup.py build_sphinx


### PR DESCRIPTION
- All testenv commands were the same so only define once.
- Move docs to its own testenv and use the same command as Travis.
- Replace deprecated [] with {posargs}