### PR TITLE
Skip failure test on pypy2 and make pypy2 mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
       dist: xenial
     - python: "nightly"
       dist: xenial
-  allow_failures:
-  - python: pypy
 install:
  - pip install -U pip
  - pip install -U wheel setuptools

--- a/mock/tests/testhelpers.py
+++ b/mock/tests/testhelpers.py
@@ -4,6 +4,7 @@
 import socket
 
 import six
+import sys
 import time
 import unittest
 
@@ -459,6 +460,8 @@ class SpecSignatureTest(unittest.TestCase):
             self._check_someclass_mock(mock)
 
 
+    @unittest.skipIf('PyPy' in sys.version and sys.version_info < (3, 0),
+                     "Fails on pypy2 due to incorrect signature for dict.pop from funcsigs")
     def test_builtin_functions_types(self):
         # we could replace builtin functions / methods with a function
         # with *args / **kwargs signature. Using the builtin method type


### PR DESCRIPTION
* Skip known failure in pypy2 . Tracked with #438 .
* Make pypy2 mandatory in Travis

Successful build : https://travis-ci.org/tirkarthi/mock/builds/471635546