### PR TITLE
Include regression tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.txt
 include *.rst
+recursive-include mock/tests *.py


### PR DESCRIPTION
Modify MANIFEST.in so that regression tests will be included in PyPI tarball.