### PR TITLE
Remove redundant license option and fix typo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,7 @@ home-page = http://mock.readthedocs.org/en/latest/
 description-file = README.rst
 author = Testing Cabal
 author-email = testing-in-python@lists.idyll.org
-license = OSI Approved :: BSD License
-classifier =
+classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers


### PR DESCRIPTION
The [Python packaging specifications](https://packaging.python.org/specifications/core-metadata) indicate that the [`license` parameter](https://packaging.python.org/specifications/core-metadata/#license) to `setup()` should be used in one of the following cases:

* the license is not a selection from the “License” Trove classifiers
* to specify a particular version of a license which is named via the `Classifier` field
* to indicate a variation or exception to such a license

This PR removes the explicit `license` parameter since the usage for this project does not fit any of those cases and it makes it more difficult to use tools like [pip-licenses](https://pypi.org/project/pip-licenses) since it is not consistent with other projects that just have `License :: OSI Approved :: BSD License` as one of their trove classifiers.

Please note that this does _not_ change the license of the project in any way, and since this project already has a `License :: OSI Approved :: BSD License` trove classifier the `license` parameter is redundant.

Furthermore, I believe that the `classifier` option should be pluralized to `classifiers`, according to [the setuptools documentation for `setup.cfg`](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files) (see the example).