### PR TITLE
fix syntax issue

### DIFF
--- a/mock/__init__.py
+++ b/mock/__init__.py
@@ -7,7 +7,7 @@ IS_PYPY = 'PyPy' in sys.version
 import mock.mock as _mock
 from mock.mock import *
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 version_info = tuple(int(p) for p in
                      re.match(r'(\d+).(\d+).(\d+)', __version__).groups())
 

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -572,7 +572,7 @@ class NonCallableMock(Base):
     side_effect = property(__get_side_effect, __set_side_effect)
 
 
-    def reset_mock(self,  visited=None,*, return_value=False, side_effect=False):
+    def reset_mock(self,  visited=None, return_value=False, side_effect=False):
         "Restore the mock object to its initial state."
         if visited is None:
             visited = []


### PR DESCRIPTION
I could not find any contributing guidelines for this project, so taking a stab at a patch this way.

Fixes syntax error introduced here: https://github.com/testing-cabal/mock/blob/ea9f71536da0ce3bd31e31b5f428f3495c6ab0dc/mock/mock.py#L575