### PR TITLE
docs| Clarifies relationship betwen import mock and import unittest.mock

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,8 @@
+This is backport, contributions which are not backport related should be done
+upstream on the `CPython version <https://github.com/python/cpython>`_.
+
+For bug-reporting see the `back-port docs
+<https://mock.readthedocs.io/en/latest/#bug-reports>`_.
+
+For all other contributions see the `maintainer docs
+<https://mock.readthedocs.io/en/latest/#maintainer-notes>`_.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@ mock is now part of the Python standard library, available as `unittest.mock
 onwards.
 
 This package contains a rolling backport of the standard library mock code
-compatible with Python 3.6 and up.
+compatible with Python 3.6 and up. That is, this module ``import mock`` follows
+the latest version of Python's official ``import unittest.mock``.
 
 Please see the standard library documentation for more details.
 

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -59,6 +59,14 @@ Python, should be reported to the `bug tracker
 with Mock functionality should be reported to the `Python bug tracker
 <https://bugs.python.org>`_.
 
+To check if the issue is a backport issue (instead of an issue with the upstream
+``unittest.mock`` module), you can first test with the latest CPython `master
+<https://github.com/python/cpython>`_ or a recent `release
+<https://github.com/python/cpython/releases>`_ first - ensuring you use ``import
+unittest.mock # upstream mock`` and not ``import mock # this module``; if the
+problem is the same then the issue is likely an issue in the upstream CPython
+version.
+
 .. index:: python changes
 
 Changelog


### PR DESCRIPTION
... especially for pre-morning-coffee brains.

We hope this will save some work for the maintainers.