### PR TITLE
Clarify documentation for assert_has_calls

### DIFF
--- a/mock/mock.py
+++ b/mock/mock.py
@@ -932,7 +932,7 @@ class NonCallableMock(Base):
 
         If `any_order` is False (the default) then the calls must be
         sequential. There can be extra calls before or after the
-        specified calls.
+        specified calls, but not in between the specified calls.
 
         If `any_order` is True then the calls can be in any order, but
         they must all appear in `mock_calls`."""


### PR DESCRIPTION
The `any_order` flag can be misleading - fix docstring to clarify that there cannot be extra calls in between the expected sequential calls even with this flag toggled to true.
```
AssertionError: Calls not found.
Expected: [call(1), call(3)]
Actual: [call(1), call(2), call(3), call(4)]
```