### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing
+project_urls =
+    Source = https://github.com/testing-cabal/mock
 keyword =
     testing, test, mock, mocking, unittest, patching, stubs, fakes, doubles
 


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.